### PR TITLE
fix signal handling

### DIFF
--- a/src/main.vala
+++ b/src/main.vala
@@ -1,23 +1,46 @@
 public class State {
     public weak Wl.Display display;
-    public Wl.Listener new_output;
-    public Wl.Listener new_input;
+
+    public Wl.Listener new_output_listener;
+    [CCode (cname = "offsetof(State, new_output_listener)")]
+    extern const int new_output_offset;
+
+    public Wl.Listener new_input_listener;
+    [CCode (cname = "offsetof(State, new_input_listener)")]
+    extern const int new_input_offset;
     
     public Wlr.Renderer renderer;
     public Wlr.Allocator allocator;
+
+    public State() {
+        new_output_listener.notify = _new_output;
+        new_input_listener.notify = _new_input;
+    }
+
+    public static void _new_output(Wl.Listener listener, void* data) {
+        unowned Wlr.Output output = (Wlr.Output) data;
+        unowned var self = Utils.get_listener_parent<State>(ref listener, new_output_offset);
+
+        self.new_output(output);
+    }
+
+    public void new_output(Wlr.Output output) {
+        Wlr.log(Wlr.LogImportance.INFO, "New output");
+        output.init_render(allocator, renderer);
+    }
+
+    public static void _new_input(Wl.Listener listener, void* data) {
+        unowned var self = Utils.get_listener_parent<State>(ref listener, new_input_offset);
+
+        self.new_input();
+    }
+
+    public void new_input() {
+        Wlr.log(Wlr.LogImportance.INFO, "New input");
+    }
 }
 
 public State state;
-
-public void new_output(Wl.Listener listener, void* data) {
-    unowned Wlr.Output output = (Wlr.Output) data;
-    
-    output.init_render(state.allocator, state.renderer);
-}
-
-public void new_input(Wl.Listener listener, void* data) {
-    
-}
 
 public void main() {
     Wlr.log_init(Wlr.LogImportance.DEBUG);
@@ -33,17 +56,14 @@ public void main() {
     }
     Wlr.log(Wlr.LogImportance.INFO, "Backend created");
     
-    var renderer = new Wlr.Renderer(backend);
+    state.renderer = new Wlr.Renderer(backend);
     Wlr.log(Wlr.LogImportance.INFO, "Renderer created");
-    var allocator = new Wlr.Allocator(backend, state.renderer);
+    state.allocator = new Wlr.Allocator(backend, state.renderer);
     Wlr.log(Wlr.LogImportance.INFO, "Allocator created");
     
     Wlr.log(Wlr.LogImportance.INFO, "Adding signals");
-    backend.new_output.add(state.new_output);
-    state.new_output.notify = new_output;
-    
-    backend.new_input.add(state.new_input);
-    state.new_input.notify = new_input;
+    backend.new_output.add(ref state.new_output_listener);
+    backend.new_input.add(ref state.new_input_listener);
     
     Wlr.log(Wlr.LogImportance.INFO, "Signals added");
     

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,6 +7,7 @@ deps = [
 
 sources = files(
     'main.vala',
+    'utils.vala',
 )
 
 executable(

--- a/src/utils.vala
+++ b/src/utils.vala
@@ -1,0 +1,5 @@
+public class Utils {
+    public static unowned T get_listener_parent<T> (ref Wl.Listener listener, int offset) {
+        return (T*)((size_t)&listener - offset);
+    }
+}

--- a/vapi/wayland-server.vapi
+++ b/vapi/wayland-server.vapi
@@ -7,7 +7,7 @@ namespace Wl {
         [CCode (cname = "wl_display_create")]
         public Display();
         public void run();
-        public Wl.EventLoop get_event_loop();
+        public unowned Wl.EventLoop get_event_loop();
     }
     
     [Compact]
@@ -23,7 +23,7 @@ namespace Wl {
     
     [CCode (cname = "struct wl_signal", free_function = "")]
     public struct Signal {
-        public void add(Listener listener);
+        public void add(ref Listener listener);
     }
     
     [CCode (cname = "struct wl_listener", free_function = "")]


### PR DESCRIPTION
Someone in the Vala discord server mentioned you were trying to create bindings for wlroots and had issues with the `wl_container_of` macro.

This is a problem I've worked on before, so here's how I solved it last time.

We can create our own thing similar to `wl_container_of` (here it's `get_listener_parent` in `utils.vala`). If we pass it the Wl.Listener and the offset of the listener within the parent struct, we can do some pointer arithmetic to get to the parent structure. We wrap this in some Vala generics so we can return the correct type.

To get the offset of the listener within the struct, we use a `CCode` annotation to inline some C code as Vala doesn't have native support for `offsetof`, I opened an issue against Vala a couple of years ago about this: https://gitlab.gnome.org/GNOME/vala/-/issues/1317

This means that if you change the name of your container class or listeners, you have to remember to update the names on the `CCode` lines too. The compiler errors won't be very clear as its inlined C and has no awareness of the Vala types.

Finally, I fixed up a couple of memory management issues which were causing crashes. When binding wlroots, you will need to be careful of correctly annotating `ref`, `unowned`, `free_function`, etc. to get the correct memory management semantics and prevent memory leaks, double frees or use after frees.